### PR TITLE
make createConnection overridable by sub classes

### DIFF
--- a/src/com/authy/api/Resource.java
+++ b/src/com/authy/api/Resource.java
@@ -131,7 +131,7 @@ public class Resource {
 		return status;
 	}
 	
-	private HttpURLConnection createConnection(URL url, String method, 
+	protected HttpURLConnection createConnection(URL url, String method, 
 			Map<String, String> options) throws Exception {
 
 		


### PR DESCRIPTION
We're working on an Authy integration and would like to get the client running on App Engine. Currently we get this exception:

```
java.lang.ClassCastException: com.google.apphosting.utils.security.urlfetch.URLFetchServiceStreamHandler$Connection cannot be cast to javax.net.ssl.HttpsURLConnection
    at com.authy.api.Resource.createConnection(Unknown Source)
    at com.authy.api.Resource.request(Unknown Source)
    at com.authy.api.Resource.post(Unknown Source)
    at com.authy.api.Users.createUser(Unknown Source)
```

App Engine supports HttpURLConnection, but not HttpsURLConnection.
So we need to be able to easily override this behaviour, hence this change.

Please merge and create a new Jar.
