### PR TITLE
FIxed getStatus() == 0 issue

### DIFF
--- a/src/com/authy/api/Users.java
+++ b/src/com/authy/api/Users.java
@@ -123,6 +123,7 @@ public class Users extends Resource {
 				Hash hash = (Hash)unmarshaller.unmarshal(new StreamSource(xml));
 				user = hash.getUser();
 			}
+			user.status = status;
 			user.setError(error);
 		}
 		catch(JAXBException e) {


### PR DESCRIPTION
When creating a user the status was never assigned because the following code (lines 123, 124)

```java
Hash hash = (Hash)unmarshaller.unmarshal(new StreamSource(xml));
user = hash.getUser();
```

Never assigned the status. This caused `user.isOk()` to always return `false` because `user.status` was always 0.

You can use the following code to test this behaviour:
```java
        /**
	 * @param args
	 */
	public static void main(String[] args) {
		
		AuthyApiClient client = new AuthyApiClient(SANDBOX_API_KEY, API_URL);
		
		// obtain a Tokens and Users instance
		Tokens tokens = client.getTokens();
		Users users = client.getUsers();
		
		log("Creating a user: ");
		User createdUser = users.createUser("fernandohur@gmail.com","315XXXXXX","XX");
		log("Done: "+createdUser + ", "+createdUser.getStatus());
		if(createdUser.isOk()){
			log("User was successfully created: "+createdUser.toMap());
		}
		else{
			Error error = createdUser.getError();
			log(error+"");
		}
		
	}
	
	public final static void log(String msg){
		System.out.println(msg);
	}
```