### PR TITLE
Remove unnecessary casting to HttpsURLConnection

### DIFF
--- a/src/com/authy/api/Resource.java
+++ b/src/com/authy/api/Resource.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import java.net.HttpURLConnection;
-import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLHandshakeException;
 
 import com.authy.AuthyApiClient;
@@ -126,12 +125,8 @@ public class Resource {
 			Map<String, String> options) throws Exception {
 
 		
-		HttpURLConnection connection = null;
-		if(testFlag)
-			connection = (HttpURLConnection)url.openConnection();
-		else
-			connection = (HttpsURLConnection)url.openConnection();
-		
+		HttpURLConnection connection = url.openConnection();
+
 		connection.setRequestMethod(method);
 		
 		for(Entry<String, String> s : options.entrySet()) {


### PR DESCRIPTION
 * This way the endpoint can always be http or https regardless of testing
 * The switch was on the test flag, which doesn't make sense, if
   anything it should be testing for the endpoint URL
 * But it doesn't even make sense for that since HttpsURLConnection is a
   subclass of HttpURLConnection, you can just use the parent class
   everywhere