### PR TITLE
Added feature for sending email token based on the authy Email

### DIFF
--- a/src/main/java/com/authy/api/Users.java
+++ b/src/main/java/com/authy/api/Users.java
@@ -26,6 +26,8 @@ public class Users extends Resource {
     public static final String ONE_CODE_CALL_PATH = "/protected/json/call/";
     public static final String USER_STATUS_PATH = "/protected/json/users/%d/status";
     public static final String DEFAULT_COUNTRY_CODE = "1";
+    /* Added for sending email tokens */
+    public static final String EMAIL_PATH = "/protected/json/email/";
 
     public Users(String uri, String key) {
         super(uri, key, Resource.JSON_CONTENT_TYPE);
@@ -103,6 +105,31 @@ public class Users extends Resource {
     public Hash requestCall(int userId, Map<String, String> options) throws AuthyException {
         MapToResponse opt = new MapToResponse(options);
         final Response response = this.get(ONE_CODE_CALL_PATH + Integer.toString(userId), opt);
+        return instanceFromJson(response.getStatus(), response.getBody());
+    }
+    
+    /**
+     * Send token via call to a user.
+     * 
+     * @param userId
+     * @return
+     * @throws AuthyException
+     */
+    public Hash requestEmail(int userId) throws AuthyException {
+        return requestEmail(userId, new HashMap<>(0));
+    }
+    
+    /**
+     * Send token via email to a user which some options defined.
+     * 
+     * @param userId
+     * @param options
+     * @return
+     * @throws AuthyException
+     */
+    public Hash requestEmail(int userId, Map<String, String> options) throws AuthyException {
+        MapToResponse opt = new MapToResponse(options);
+        final Response response = this.post(EMAIL_PATH + Integer.toString(userId), opt);
         return instanceFromJson(response.getStatus(), response.getBody());
     }
 

--- a/src/main/java/com/authy/api/Users.java
+++ b/src/main/java/com/authy/api/Users.java
@@ -109,7 +109,7 @@ public class Users extends Resource {
     }
     
     /**
-     * Send token via call to a user.
+     * Send token via email to a user.
      * 
      * @param userId
      * @return


### PR DESCRIPTION
Integration flow

<!-- Describe your Pull Request -->
This feature is added for allowing the api to send OTP as email to the user. Using the SDK we can do the following

```
Hash hash = apiClient.getUsers().requestEmail(USER_AUTHY_ID);
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
