### PR TITLE
Fix JSON related flaky tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,11 @@
 
     <dependencies>
         <dependency>
-			<groupId>org.skyscreamer</groupId>
-			<artifactId>jsonassert</artifactId>
-			<version>1.5.0</version>
-			<scope>test</scope>
-		</dependency>
+	    <groupId>org.skyscreamer</groupId>
+	    <artifactId>jsonassert</artifactId>
+	    <version>1.5.0</version>
+	    <scope>test</scope>
+	</dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
 
     <dependencies>
         <dependency>
+			<groupId>org.skyscreamer</groupId>
+			<artifactId>jsonassert</artifactId>
+			<version>1.5.0</version>
+			<scope>test</scope>
+		</dependency>
+        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20150729</version>

--- a/src/test/java/com/authy/api/UserStatusTest.java
+++ b/src/test/java/com/authy/api/UserStatusTest.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 public class UserStatusTest {
 
     public static final int USER_ID = 1234;
@@ -17,6 +20,17 @@ public class UserStatusTest {
     public static final String DEVICE_A = "deviceA";
     public static final String DEVICE_B = "deviceB";
     private UserStatus userStatus;
+
+    /**
+     * Compare JSON string without enforcing the order
+     */
+    public void assertJsonEqualsNonStrict(String json1, String json2) {
+        try {
+            JSONAssert.assertEquals(json1, json2, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }
+    }
 
     @Before
     public void setup() {
@@ -63,7 +77,7 @@ public class UserStatusTest {
     public void testToJSON() {
         String userStatusJson = userStatus.toJSON();
         assertNotNull(userStatusJson);
-        assertEquals(userStatusJson, "{\"phoneNumber\":\"456 758 8990\"," +
+        assertJsonEqualsNonStrict(userStatusJson, "{\"phoneNumber\":\"456 758 8990\"," +
                 "\"devices\":\"[deviceA, deviceB]\",\"success\":\"true\"," +
                 "\"countryCode\":\"1\",\"registered\":\"true\",\"userId\":\"1234\",\"confirmed\":\"true\"}");
     }


### PR DESCRIPTION
**Description**
The test
```
com.authy.api.UserStatusTest#testToJSON
```
failed under environment [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detect flakiness under non-deterministic data structure usages. 

Whereas `toJson` utilize `HashMap` internally, so the order of objects might not be guaranteed. I added a library that tests JSON object without enforcing the order.

**To Reproduce**
```sh
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.authy.api.UserStatusTest#testToJSON  -DnondexSeed=933178
```
Please let me know if you have any question!

# 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ x ] I acknowledge that all my contributions will be made under the project's license.
